### PR TITLE
Fix type hint

### DIFF
--- a/src/clojure/clojurewerkz/streampunk/stream_lib/q_digest.clj
+++ b/src/clojure/clojurewerkz/streampunk/stream_lib/q_digest.clj
@@ -13,6 +13,6 @@
   [^IQuantileEstimator algo ^long val]
   (.offer algo val))
 
-(defn ^long get-quantile
-  [^IQuantileEstimator algo ^double q]
+(defn get-quantile
+  ^long [^IQuantileEstimator algo ^double q]
   (.getQuantile algo q))


### PR DESCRIPTION
Var meta is evaluated (here to the clojure.core/long function). Fixed by making it the return type hint of the signature.
